### PR TITLE
Update receipt destroying

### DIFF
--- a/app/controllers/api/v1/receipts_controller.rb
+++ b/app/controllers/api/v1/receipts_controller.rb
@@ -4,7 +4,7 @@ module Api
       load_and_authorize_resource :transaction, id_param: :transaction_id, only: :destroy
 
       def destroy
-        return render_success({}, 200) if @transaction.receipt.destroy
+        return render_success(@transaction.reload, 200) if @transaction.receipt.destroy
 
         render_jsonapi_errors @transaction.receipt
       end

--- a/app/serializers/transaction_serializer.rb
+++ b/app/serializers/transaction_serializer.rb
@@ -27,9 +27,10 @@ class TransactionSerializer < ActiveModel::Serializer
   def receipt
     receipt = @object.receipt
 
-    return {} unless receipt
+    return unless receipt
 
     {
+      filename: receipt.receipt.original_filename,
       original: receipt.receipt_url,
       thumbnail: receipt.receipt_url(:thumbnail)
     }

--- a/config/initializers/shrine.rb
+++ b/config/initializers/shrine.rb
@@ -7,13 +7,13 @@ if Rails.env.test?
       cache: Shrine::Storage::Memory.new,
       receipt: Shrine::Storage::Memory.new,
   }
-elsif Rails.env.development?
-  require "shrine/storage/file_system"
-
-  Shrine.storages = {
-      cache: Shrine::Storage::FileSystem.new("public", prefix: "uploads/cache"),
-      receipt: Shrine::Storage::FileSystem.new("public", prefix: "uploads/receipt")
-  }
+# elsif Rails.env.development?
+#   require "shrine/storage/file_system"
+#
+#   Shrine.storages = {
+#       cache: Shrine::Storage::FileSystem.new("public", prefix: "uploads/cache"),
+#       receipt: Shrine::Storage::FileSystem.new("public", prefix: "uploads/receipt")
+#   }
 else
   require "shrine/storage/s3"
 


### PR DESCRIPTION
1. Use `S3` for `Development`

2. Send back updated `Transaction`, when `Receipt` destroyed.